### PR TITLE
Fix instagram read receipt blocker extension

### DIFF
--- a/Ghost-dm/background.js
+++ b/Ghost-dm/background.js
@@ -14,24 +14,28 @@ chrome.runtime.onInstalled.addListener(async () => {
 
 // Initialize on startup
 chrome.runtime.onStartup.addListener(async () => {
-  await initializeGhostMode();
+  await initializeGhostMode(true);
 });
 
 // Initialize when service worker starts
 (async () => {
-  await initializeGhostMode();
+  await initializeGhostMode(true);
 })();
 
 /**
  * Initialize Ghost Mode based on stored state
  */
-async function initializeGhostMode() {
+async function initializeGhostMode(shouldInjectTabs = false) {
   try {
     const result = await chrome.storage.sync.get(['ghostMode']);
     const ghostMode = result.ghostMode || false;
     
     if (ghostMode) {
       await enableRuleset();
+      if (shouldInjectTabs) {
+        await injectContentScriptToAllInstagramTabs();
+        notifyContentScripts(true);
+      }
     } else {
       await disableRuleset();
     }
@@ -108,13 +112,18 @@ async function disableRuleset() {
 }
 
 /**
- * Inject content script into active tab
+ * Inject content scripts into active tab
  */
 async function injectContentScriptToActiveTab() {
   try {
     const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
     
     if (tab && tab.url && tab.url.includes('instagram.com')) {
+      await chrome.scripting.executeScript({
+        target: { tabId: tab.id },
+        files: ['early-inject.js'],
+        world: 'MAIN'
+      });
       await chrome.scripting.executeScript({
         target: { tabId: tab.id },
         files: ['content.js']
@@ -126,7 +135,7 @@ async function injectContentScriptToActiveTab() {
 }
 
 /**
- * Inject content script into all Instagram tabs
+ * Inject content scripts into all Instagram tabs
  */
 async function injectContentScriptToAllInstagramTabs() {
   try {
@@ -134,6 +143,11 @@ async function injectContentScriptToAllInstagramTabs() {
     
     for (const tab of tabs) {
       try {
+        await chrome.scripting.executeScript({
+          target: { tabId: tab.id },
+          files: ['early-inject.js'],
+          world: 'MAIN'
+        });
         await chrome.scripting.executeScript({
           target: { tabId: tab.id },
           files: ['content.js']

--- a/Ghost-dm/content.js
+++ b/Ghost-dm/content.js
@@ -1,271 +1,89 @@
 /**
  * Content script for Ghost DM extension
- * Provides comprehensive read receipt blocking on Instagram pages
+ * Bridges Ghost Mode state and displays toasts
  */
 
-let ghostModeEnabled = false;
-let blockingActive = false;
+if (window.__ghostDM_contentInitialized) {
+  // Prevent duplicate initialization
+} else {
+  window.__ghostDM_contentInitialized = true;
 
-// Initialize content script
-(function() {
-  // Check initial Ghost Mode state
-  chrome.runtime.sendMessage({ action: 'getGhostMode' }, (response) => {
-    if (response) {
-      ghostModeEnabled = response.enabled;
-      if (ghostModeEnabled) {
-        initializeBlocking();
-        showToast('Ghost Mode is active', 'info');
-      }
-    }
-  });
-  
-  // Listen for Ghost Mode changes
-  chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
-    if (request.action === 'ghostModeChanged') {
-      ghostModeEnabled = request.enabled;
-      
-      if (ghostModeEnabled) {
-        initializeBlocking();
-        showToast('Ghost Mode enabled', 'success');
-      } else {
-        showToast('Ghost Mode disabled', 'info');
-      }
-    }
-  });
-})();
+  let ghostModeEnabled = false;
 
-/**
- * Initialize comprehensive request blocking
- */
-function initializeBlocking() {
-  if (blockingActive) return;
-  blockingActive = true;
-  
-  // Block fetch requests
-  const originalFetch = window.fetch;
-  window.fetch = function(...args) {
-    if (!ghostModeEnabled) {
-      return originalFetch.apply(this, args);
-    }
-    
-    const url = args[0];
-    const options = args[1] || {};
-    
-    if (typeof url === 'string' && shouldBlockRequest(url, options)) {
-      showToast('Read receipt blocked', 'success');
-      
-      // Return fake successful response
-      return Promise.resolve(new Response(JSON.stringify({
-        status: 'ok',
-        success: true
-      }), {
-        status: 200,
-        statusText: 'OK',
-        headers: { 'Content-Type': 'application/json' }
-      }));
-    }
-    
-    return originalFetch.apply(this, args);
-  };
-  
-  // Block XMLHttpRequest
-  const originalXHROpen = XMLHttpRequest.prototype.open;
-  const originalXHRSend = XMLHttpRequest.prototype.send;
-  
-  XMLHttpRequest.prototype.open = function(method, url, ...args) {
-    this._ghostDM_url = url;
-    this._ghostDM_method = method;
-    this._ghostDM_blocked = ghostModeEnabled && shouldBlockRequest(url, { method });
-    
-    if (this._ghostDM_blocked) {
-      showToast('Read receipt blocked', 'success');
-      
-      // Create fake XHR that appears successful
-      this.readyState = 4;
-      this.status = 200;
-      this.statusText = 'OK';
-      this.responseText = '{"status":"ok","success":true}';
-      this.response = this.responseText;
-      
-      // Set up fake event handling
-      setTimeout(() => {
-        if (this.onreadystatechange) {
-          this.onreadystatechange();
+  (function() {
+    // Initialize Ghost Mode state
+    chrome.runtime.sendMessage({ action: 'getGhostMode' }, (response) => {
+      if (response) {
+        ghostModeEnabled = !!response.enabled;
+        // Inform page (main world injection) about current state
+        try { window.dispatchEvent(new CustomEvent('GhostDMSetEnabled', { detail: ghostModeEnabled })); } catch (_) {}
+        if (ghostModeEnabled) {
+          showToast('Ghost Mode is active', 'info');
         }
-        if (this.onload) {
-          this.onload();
-        }
-      }, 1);
-      
-      return;
-    }
-    
-    return originalXHROpen.apply(this, [method, url, ...args]);
-  };
-  
-  XMLHttpRequest.prototype.send = function(data) {
-    if (this._ghostDM_blocked) {
-      return; // Already handled in open()
-    }
-    return originalXHRSend.apply(this, arguments);
-  };
-  
-  // Block WebSocket messages
-  const originalWebSocket = window.WebSocket;
-  window.WebSocket = function(url, protocols) {
-    const ws = new originalWebSocket(url, protocols);
-    
-    const originalSend = ws.send;
-    ws.send = function(data) {
-      if (ghostModeEnabled && shouldBlockWebSocketMessage(data)) {
-        showToast('WebSocket read receipt blocked', 'success');
-        return; // Block the message
       }
-      
-      return originalSend.apply(this, arguments);
-    };
+    });
     
-    return ws;
-  };
-}
+    // Listen for Ghost Mode changes
+    chrome.runtime.onMessage.addListener((request) => {
+      if (request.action === 'ghostModeChanged') {
+        ghostModeEnabled = !!request.enabled;
+        try { window.dispatchEvent(new CustomEvent('GhostDMSetEnabled', { detail: ghostModeEnabled })); } catch (_) {}
+        showToast(ghostModeEnabled ? 'Ghost Mode enabled' : 'Ghost Mode disabled', ghostModeEnabled ? 'success' : 'info');
+      }
+    });
+    
+    // Listen for block events from main world
+    window.addEventListener('GhostDMBlocked', (e) => {
+      showToast('Read receipt blocked', 'success');
+    });
+  })();
 
-/**
- * Determine if a request should be blocked based on URL and options
- */
-function shouldBlockRequest(url, options = {}) {
-  if (!url || typeof url !== 'string') return false;
-  
-  const method = options.method || 'GET';
-  const lowerUrl = url.toLowerCase();
-  const requestBody = options.body ? options.body.toString().toLowerCase() : '';
-  
-  // Instagram read receipt patterns
-  const blockPatterns = [
-    '/direct_v2/threads/',
-    '/api/v1/direct/',
-    '/web/direct_v2/',
-    '/graphql/',
-    '/seen',
-    'mark_seen',
-    'seen_indicator',
-    'seen_state',
-    'read_receipt',
-    '/direct/thread/',
-    '/mark_read',
-    '/update_read_state',
-    '/direct_v2/mark_seen',
-    '/direct_v2/inbox/mark_seen'
-  ];
-  
-  const hasBlockPattern = blockPatterns.some(pattern => lowerUrl.includes(pattern));
-  
-  // GraphQL mutation blocking
-  if (lowerUrl.includes('/graphql/') && requestBody) {
-    const graphqlBlockMutations = [
-      'markdirectinboxitemseen',
-      'directmarkseenmutation', 
-      'updatethreadseenstate',
-      'markthreadseen'
-    ];
-    
-    const isBlockedMutation = graphqlBlockMutations.some(mutation => 
-      requestBody.includes(mutation)
-    );
-    
-    if (isBlockedMutation || requestBody.includes('seen')) {
-      return true;
+  /**
+   * Display toast notification
+   */
+  function showToast(message, type = 'info') {
+    let toastContainer = document.getElementById('ghost-dm-toast-container');
+    if (!toastContainer) {
+      toastContainer = document.createElement('div');
+      toastContainer.id = 'ghost-dm-toast-container';
+      toastContainer.style.cssText = `
+        position: fixed;
+        top: 20px;
+        right: 20px;
+        z-index: 999999;
+        pointer-events: none;
+      `;
+      const mountTarget = document.body || document.documentElement || document.head;
+      if (mountTarget) {
+        mountTarget.appendChild(toastContainer);
+      }
     }
-  }
-  
-  // Block POST/PUT/PATCH requests to read receipt endpoints
-  if (hasBlockPattern && ['POST', 'PUT', 'PATCH'].includes(method.toUpperCase())) {
-    return true;
-  }
-  
-  // Block any URL specifically mentioning "seen"
-  if (lowerUrl.includes('seen')) {
-    return true;
-  }
-  
-  return false;
-}
-
-/**
- * Determine if a WebSocket message should be blocked
- */
-function shouldBlockWebSocketMessage(data) {
-  if (!data || typeof data !== 'string') return false;
-  
-  try {
-    const parsed = JSON.parse(data);
-    const dataStr = JSON.stringify(parsed).toLowerCase();
     
-    const blockKeywords = [
-      'seen', 'read_receipt', 'mark_read', 'seen_indicator',
-      'direct', 'thread', 'inbox', 'message'
-    ];
-    
-    return blockKeywords.some(keyword => dataStr.includes(keyword));
-  } catch (e) {
-    // If not JSON, check raw string
-    const lowerData = data.toLowerCase();
-    return lowerData.includes('seen') || 
-           lowerData.includes('read_receipt') || 
-           lowerData.includes('mark_read');
-  }
-}
-
-/**
- * Display toast notification
- */
-function showToast(message, type = 'info') {
-  // Create toast container if it doesn't exist
-  let toastContainer = document.getElementById('ghost-dm-toast-container');
-  if (!toastContainer) {
-    toastContainer = document.createElement('div');
-    toastContainer.id = 'ghost-dm-toast-container';
-    toastContainer.style.cssText = `
-      position: fixed;
-      top: 20px;
-      right: 20px;
-      z-index: 999999;
-      pointer-events: none;
+    const toast = document.createElement('div');
+    toast.className = `ghost-dm-toast ghost-dm-toast-${type}`;
+    toast.textContent = message;
+    toast.style.cssText = `
+      background: rgba(0, 0, 0, 0.8);
+      color: white;
+      padding: 12px 16px;
+      border-radius: 8px;
+      margin-bottom: 8px;
+      font-size: 14px;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      transform: translateX(100%);
+      transition: transform 0.3s ease;
+      max-width: 300px;
+      word-wrap: break-word;
     `;
-    document.body.appendChild(toastContainer);
-  }
-  
-  // Create toast element
-  const toast = document.createElement('div');
-  toast.className = `ghost-dm-toast ghost-dm-toast-${type}`;
-  toast.textContent = message;
-  toast.style.cssText = `
-    background: rgba(0, 0, 0, 0.8);
-    color: white;
-    padding: 12px 16px;
-    border-radius: 8px;
-    margin-bottom: 8px;
-    font-size: 14px;
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-    transform: translateX(100%);
-    transition: transform 0.3s ease;
-    max-width: 300px;
-    word-wrap: break-word;
-  `;
-  
-  toastContainer.appendChild(toast);
-  
-  // Show toast
-  setTimeout(() => {
-    toast.style.transform = 'translateX(0)';
-  }, 100);
-  
-  // Hide and remove toast
-  setTimeout(() => {
-    toast.style.transform = 'translateX(100%)';
+    
+    if (toastContainer && toastContainer.appendChild) {
+      toastContainer.appendChild(toast);
+    }
+    
+    setTimeout(() => { toast.style.transform = 'translateX(0)'; }, 100);
     setTimeout(() => {
-      if (toast.parentNode) {
-        toast.parentNode.removeChild(toast);
-      }
-    }, 300);
-  }, 3000);
+      toast.style.transform = 'translateX(100%)';
+      setTimeout(() => { toast.parentNode && toast.parentNode.removeChild(toast); }, 300);
+    }, 3000);
+  }
 } 

--- a/Ghost-dm/early-inject.js
+++ b/Ghost-dm/early-inject.js
@@ -11,63 +11,259 @@
     return;
   }
   
-  let ghostModeEnabled = false;
-  
-  // Initialize Ghost Mode state from storage
-  if (typeof chrome !== 'undefined' && chrome.storage) {
-    chrome.storage.sync.get(['ghostMode'], (result) => {
-      ghostModeEnabled = result.ghostMode || false;
-    });
+  // Bridge: dispatch a CustomEvent to the page to set enabled state
+  function dispatchSetEnabledToPage(enabled) {
+    try {
+      window.dispatchEvent(new CustomEvent('GhostDMSetEnabled', { detail: !!enabled }));
+    } catch (e) {}
   }
   
-  // Listen for Ghost Mode changes
-  if (typeof chrome !== 'undefined' && chrome.runtime) {
-    chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
-      if (request.action === 'ghostModeChanged') {
-        ghostModeEnabled = request.enabled;
-      }
-    });
+  // Inject a script tag that runs in the page's main world
+  function injectMainWorldScript(initialEnabled) {
+    const code = `(() => {
+      'use strict';
+      try {
+        if (window.__ghostDM_injected) { return; }
+        window.__ghostDM_injected = true;
+        const GHOST_EVENT_BLOCKED = 'GhostDMBlocked';
+        const GHOST_EVENT_SET_ENABLED = 'GhostDMSetEnabled';
+        let ghostModeEnabled = ${initialEnabled ? 'true' : 'false'};
+        
+        // Listen for state updates from the extension world
+        window.addEventListener(GHOST_EVENT_SET_ENABLED, (e) => {
+          try { ghostModeEnabled = !!(e && e.detail); } catch (_) {}
+        });
+        
+        function dispatchBlocked(detail) {
+          try { window.dispatchEvent(new CustomEvent(GHOST_EVENT_BLOCKED, { detail })); } catch (_) {}
+        }
+        
+        function toLowerSafe(value) {
+          try { return (value || '').toString().toLowerCase(); } catch (_) { return ''; }
+        }
+        
+        function bodyToString(body) {
+          try {
+            if (!body) return '';
+            if (typeof body === 'string') return body;
+            if (body instanceof URLSearchParams) return body.toString();
+            if (body instanceof FormData) {
+              const parts = [];
+              for (const [k, v] of body.entries()) { parts.push(k + '=' + (typeof v === 'string' ? v : 'blob')); }
+              return parts.join('&');
+            }
+            // Try JSON stringify for objects
+            return JSON.stringify(body);
+          } catch (_) {
+            return '';
+          }
+        }
+        
+        function shouldBlockUrlAndMethod(url, method, requestBodyStr) {
+          if (!url) return false;
+          const lowerUrl = toLowerSafe(url);
+          const m = toLowerSafe(method || 'get');
+          const isWrite = m === 'post' || m === 'put' || m === 'patch';
+          
+          // Focus only on write requests
+          if (!isWrite) {
+            return false;
+          }
+          
+          // Primary REST patterns used by Instagram DMs
+          const patterns = [
+            '/direct_v2/threads/',
+            '/api/v1/direct_v2/',
+            '/web/direct_v2/',
+            '/direct/thread/',
+            '/direct/',
+          ];
+          const hasDmPath = patterns.some(p => lowerUrl.includes(p));
+          
+          // Blockers in either URL or body
+          const keywords = [
+            '/seen',
+            'mark_seen',
+            'mark_read',
+            'seen_indicator',
+            'seen_state',
+            'read_receipt',
+            '/update_read_state',
+            '/inbox/mark_seen',
+          ];
+          const hasKeywordsInUrl = keywords.some(k => lowerUrl.includes(k));
+          
+          if (hasDmPath && hasKeywordsInUrl) {
+            return true;
+          }
+          
+          // GraphQL mutations
+          if (lowerUrl.includes('/graphql')) {
+            const body = toLowerSafe(requestBodyStr);
+            if (!body) return false;
+            const gqlKeywords = [
+              'markdirectinboxitemseen',
+              'directmarkseenmutation',
+              'updatethreadseenstate',
+              'markthreadseen',
+              'mark_seen',
+              'seen'
+            ];
+            if (gqlKeywords.some(k => body.includes(k))) return true;
+          }
+          
+          // Generic fallback: any DM URL explicitly containing 'seen'
+          if (hasDmPath && lowerUrl.includes('seen')) return true;
+          return false;
+        }
+        
+        // fetch
+        try {
+          const originalFetch = window.fetch;
+          if (typeof originalFetch === 'function') {
+            window.fetch = function(input, init) {
+              if (!ghostModeEnabled) {
+                return originalFetch.apply(this, arguments);
+              }
+              try {
+                const url = (typeof input === 'string') ? input : (input && input.url);
+                const method = init && (init.method || (input && input.method));
+                const bodyStr = init && bodyToString(init.body);
+                if (shouldBlockUrlAndMethod(url, method, bodyStr)) {
+                  dispatchBlocked({ type: 'fetch', url });
+                  return Promise.resolve(new Response(JSON.stringify({ status: 'ok', success: true }), {
+                    status: 200,
+                    statusText: 'OK',
+                    headers: { 'Content-Type': 'application/json' }
+                  }));
+                }
+              } catch (_) {}
+              return originalFetch.apply(this, arguments);
+            };
+          }
+        } catch (_) {}
+        
+        // XHR
+        try {
+          const originalOpen = XMLHttpRequest.prototype.open;
+          const originalSend = XMLHttpRequest.prototype.send;
+          XMLHttpRequest.prototype.open = function(method, url) {
+            this.__ghostDM = { method, url, blocked: false };
+            try {
+              const bodyStr = '';
+              if (ghostModeEnabled && shouldBlockUrlAndMethod(url, method, bodyStr)) {
+                this.__ghostDM.blocked = true;
+              }
+            } catch (_) {}
+            return originalOpen.apply(this, arguments);
+          };
+          XMLHttpRequest.prototype.send = function(body) {
+            try {
+              if (this.__ghostDM && !this.__ghostDM.blocked && ghostModeEnabled) {
+                const { method, url } = this.__ghostDM;
+                const bodyStr = bodyToString(body);
+                if (shouldBlockUrlAndMethod(url, method, bodyStr)) {
+                  this.__ghostDM.blocked = true;
+                }
+              }
+              if (this.__ghostDM && this.__ghostDM.blocked) {
+                // Simulate successful response
+                dispatchBlocked({ type: 'xhr', url: this.__ghostDM.url });
+                this.readyState = 4;
+                this.status = 200;
+                this.statusText = 'OK';
+                this.responseType = '';
+                this.responseText = '{"status":"ok","success":true}';
+                this.response = this.responseText;
+                const self = this;
+                setTimeout(() => {
+                  try { if (typeof self.onreadystatechange === 'function') self.onreadystatechange(); } catch (_) {}
+                  try { if (typeof self.onload === 'function') self.onload(); } catch (_) {}
+                }, 0);
+                return;
+              }
+            } catch (_) {}
+            return originalSend.apply(this, arguments);
+          };
+        } catch (_) {}
+        
+        // WebSocket
+        try {
+          const OriginalWebSocket = window.WebSocket;
+          window.WebSocket = function(url, protocols) {
+            const ws = new OriginalWebSocket(url, protocols);
+            try {
+              const originalSend = ws.send;
+              ws.send = function(data) {
+                try {
+                  if (ghostModeEnabled) {
+                    const text = toLowerSafe(typeof data === 'string' ? data : JSON.stringify(data));
+                    if (text && (text.includes('seen') || text.includes('mark_read') || text.includes('mark_seen'))) {
+                      dispatchBlocked({ type: 'websocket' });
+                      return;
+                    }
+                  }
+                } catch (_) {}
+                return originalSend.apply(this, arguments);
+              };
+            } catch (_) {}
+            return ws;
+          };
+        } catch (_) {}
+        
+        // sendBeacon
+        try {
+          const originalSendBeacon = navigator.sendBeacon && navigator.sendBeacon.bind(navigator);
+          if (originalSendBeacon) {
+            navigator.sendBeacon = function(url, data) {
+              try {
+                if (ghostModeEnabled) {
+                  const bodyStr = bodyToString(data);
+                  if (shouldBlockUrlAndMethod(url, 'POST', bodyStr)) {
+                    dispatchBlocked({ type: 'beacon', url });
+                    return true; // Pretend success
+                  }
+                }
+              } catch (_) {}
+              return originalSendBeacon(url, data);
+            };
+          }
+        } catch (_) {}
+        
+        // Expose flag for debugging
+        try { window.__ghostDM_injected = true; } catch (_) {}
+      } catch (_) {}
+    })();`;
+    const script = document.createElement('script');
+    script.textContent = code;
+    (document.documentElement || document.head || document.body).appendChild(script);
+    // Remove the script element to keep DOM clean
+    script.parentNode && script.parentNode.removeChild(script);
   }
   
-  // Override fetch to block read receipt requests
-  const originalFetch = window.fetch;
-  window.fetch = function(...args) {
-    const url = args[0];
-    const options = args[1] || {};
-    
-    if (ghostModeEnabled && typeof url === 'string' && url.includes('/seen')) {
-      // Return fake successful response
-      return Promise.resolve(new Response(JSON.stringify({
-        status: 'ok',
-        success: true
-      }), {
-        status: 200,
-        statusText: 'OK',
-        headers: { 'Content-Type': 'application/json' }
-      }));
+  // Inject immediately to hook as early as possible (enabled defaults to false)
+  try { injectMainWorldScript(false); } catch (_) {}
+  
+  // Read state from storage and forward to page
+  try {
+    if (typeof chrome !== 'undefined' && chrome.storage && chrome.storage.sync) {
+      chrome.storage.sync.get(['ghostMode'], (result) => {
+        try { dispatchSetEnabledToPage(!!(result && result.ghostMode)); } catch (_) {}
+      });
     }
-    
-    return originalFetch.apply(this, args);
-  };
+  } catch (e) {}
   
-  // Override WebSocket to block read receipt messages
-  const originalWebSocket = window.WebSocket;
-  window.WebSocket = function(url, protocols) {
-    const ws = new originalWebSocket(url, protocols);
-    
-    const originalSend = ws.send;
-    ws.send = function(data) {
-      if (ghostModeEnabled && typeof data === 'string' && data.includes('seen')) {
-        return; // Block the message
-      }
-      
-      return originalSend.apply(this, arguments);
-    };
-    
-    return ws;
-  };
+  // Listen for Ghost Mode changes and forward to page
+  try {
+    if (typeof chrome !== 'undefined' && chrome.runtime) {
+      chrome.runtime.onMessage.addListener((request) => {
+        if (request && request.action === 'ghostModeChanged') {
+          dispatchSetEnabledToPage(!!request.enabled);
+        }
+      });
+    }
+  } catch (e) {}
   
   // Mark early injection as complete
   window.ghostDM_earlyInjection = true;
-  
 })(); 

--- a/Ghost-dm/rules.json
+++ b/Ghost-dm/rules.json
@@ -2,13 +2,51 @@
   {
     "id": 1,
     "priority": 1,
-    "action": {
-      "type": "block"
-    },
+    "action": { "type": "block" },
     "condition": {
-      "urlFilter": "*/direct_v2/threads/*/seen",
-      "domains": ["instagram.com"],
-      "resourceTypes": ["xmlhttprequest"]
+      "urlFilter": "*://*.instagram.com/api/v1/direct_v2/threads/*/seen*",
+      "domains": ["instagram.com", "www.instagram.com", "i.instagram.com"],
+      "resourceTypes": ["xmlhttprequest", "ping"]
+    }
+  },
+  {
+    "id": 2,
+    "priority": 1,
+    "action": { "type": "block" },
+    "condition": {
+      "urlFilter": "*://*.instagram.com/api/v1/direct_v2/threads/*/items/*/seen*",
+      "domains": ["instagram.com", "www.instagram.com", "i.instagram.com"],
+      "resourceTypes": ["xmlhttprequest", "ping"]
+    }
+  },
+  {
+    "id": 3,
+    "priority": 1,
+    "action": { "type": "block" },
+    "condition": {
+      "urlFilter": "*://*.instagram.com/api/v1/direct_v2/inbox/mark_seen*",
+      "domains": ["instagram.com", "www.instagram.com", "i.instagram.com"],
+      "resourceTypes": ["xmlhttprequest", "ping"]
+    }
+  },
+  {
+    "id": 4,
+    "priority": 1,
+    "action": { "type": "block" },
+    "condition": {
+      "urlFilter": "*://*.instagram.com/api/v1/direct_v2/mark_seen*",
+      "domains": ["instagram.com", "www.instagram.com", "i.instagram.com"],
+      "resourceTypes": ["xmlhttprequest", "ping"]
+    }
+  },
+  {
+    "id": 5,
+    "priority": 1,
+    "action": { "type": "block" },
+    "condition": {
+      "urlFilter": "*://*.instagram.com/web/direct_v2/*seen*",
+      "domains": ["instagram.com", "www.instagram.com", "i.instagram.com"],
+      "resourceTypes": ["xmlhttprequest", "ping"]
     }
   }
 ] 


### PR DESCRIPTION
Fixes Instagram read receipt blocking by improving main-world injection and updating blocked endpoints.

The previous implementation failed to reliably intercept all relevant network requests (fetch, XHR, WebSocket, sendBeacon) in the page's main world and did not cover all current Instagram read receipt endpoints. This update ensures comprehensive blocking by injecting a script directly into the page's main execution context to override network APIs and by expanding the declarative net request rules to cover more "seen" and "mark_read" endpoints, including those sent via `sendBeacon`.

---
<a href="https://cursor.com/background-agent?bcId=bc-32fa0c1a-3a1d-4d34-974f-42cdd7ecdcab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-32fa0c1a-3a1d-4d34-974f-42cdd7ecdcab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

